### PR TITLE
Remove confusing comment

### DIFF
--- a/baretest.js
+++ b/baretest.js
@@ -19,7 +19,6 @@ module.exports = function(headline) {
   self.after = function(fn) { after.push(fn)  }
   self.skip = function(fn) {}
 
-  // for testing Baretest
   self.run = async function() {
     const tests = only[0] ? only : suite
 


### PR DESCRIPTION
The comment suggests that the `run` function is only useful for testing the Baretest library. This is wrong: all users of Baretest will call the `run` function after defining their tests.