### PR TITLE
Give `run` a consistent return type of `boolean`

### DIFF
--- a/baretest.js
+++ b/baretest.js
@@ -42,6 +42,7 @@ module.exports = function(headline) {
     for (const fn of after) await fn()
     rgb.greenln(`✓ ${ tests.length }`)
     console.info('\n')
+    return true
   }
 
   return self


### PR DESCRIPTION
`run` contains a line `return false` for if an error is thrown during a test, but it has no other returns. Thus, if all tests pass, `run` returns `undefined`. (To be technical, all these returns are inside a Promise, but that’s not relevant to this change).

Returning either `undefined` for no failures or `false` for failures is an inconsistent API. Either `run` should always return `undefined` or it should return `false` for failures and `true` for no failures. In this commit I have gone with that second alternative.