### PR TITLE
feature: add groups and allow toggling quiet output

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,21 @@ test('reject duplicate emails', async function() {
   })
 })
 
+// you can group tests together in the output if you'd like
+test.group('test group')
+
+test('first test in group', async function() {
+  assert.equals(true, true)
+})
+
+test('another test in group', async function() {
+  assert.equals(true, true)
+})
+
 // ...
+
+// you can make your test output more verbose by setting quiet to false
+test.quiet(false) // default is true, which has concise output
 
 !(async function() {
   await test.run()


### PR DESCRIPTION
Allow for test groups and more verbose output. Submitted with the expectation of discussion on these changes, since they're significant, even if they don't break backwards compatibility.

Examples:

No groups, quiet output (current behavior, but output is slightly changed)
```console
headline
• • • • • • 
✓ 6
```

Groups + default quiet output
```console
headline

  group 1 • • 
  group 2 • • 
  group 3 • • 
✓ 6
```

Groups + quiet output disabled
```console
headline
  group 1
    first test name ✓
    second test name ✓
  group 2
    first test name ✓
    second test name ✓
  group 3
    first test name ✓
    second test name ✓

✓ 6
```