### PR TITLE
feature: add TAP output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,21 @@ test('reject duplicate emails', async function() {
   })
 })
 
+// you can group tests together in the output if you'd like
+test.group('test group')
+
+test('first test in group', async function() {
+  assert.equals(true, true)
+})
+
+test('another test in group', async function() {
+  assert.equals(true, true)
+})
+
 // ...
+
+// you can make your test output more verbose by setting quiet to false
+test.quiet(false) // default is true, which has concise output
 
 !(async function() {
   await test.run()

--- a/baretest.js
+++ b/baretest.js
@@ -7,7 +7,11 @@ module.exports = function(headline) {
     after = [],
     only = []
 
-  let quiet = true
+  let bail = true,
+    quiet = true,
+    tap = false,
+    count = 0,
+    passed = true
 
   function self(name, fn) {
     suite.push({ name: name, fn: fn })
@@ -25,58 +29,113 @@ module.exports = function(headline) {
     suite.push({ group: name })
   }
 
-  self.quiet = function(_quiet) {
-    quiet = _quiet
-  }
+  self.bail = function(_bail) { bail = _bail }
+  self.quiet = function(_quiet) { quiet = _quiet }
+  self.tap = function(_tap) { tap = _tap }
 
   self.run = async function() {
     const tests = only[0] ? only : suite
 
-    rgb.cyan(headline + '\n')
+    if (tap) {
+      console.log(`# ${ headline }`)
+      console.log(`1..${ tests.filter(test => typeof test.group === 'undefined').length}`)
+    }
+    else {
+      rgb.cyan(headline + '\n')
+    }
 
     for (const test of tests) {
       if (test.group) {
-        rgb.cyan(`${ quiet ? '\n' : '' }  ${ test.group }${ quiet ? ' ' : '\n' }`)
+        emit(test)
         continue
       }
 
       try {
+        ++count;
         for (const fn of before) await fn()
         await test.fn()
-        if (quiet) {
-          rgb.gray('• ')
-        }
-        else {
-          rgb.gray(`    ${ test.name } `)
-        }
-
+        emit({
+          count,
+          test,
+          passed: true
+        });
       } catch(e) {
         for (const fn of after) await fn()
-        if (quiet) {
-          rgb.red(`\n\n! ${test.name} \n\n`)
-        }
-        else {
-          rgb.redln('✘')
-        }
-        prettyError(e)
-        return false
-      }
 
-      if (!quiet) {
-        rgb.greenln('✓')
+        emit({
+          count,
+          test,
+          failed: true,
+          e
+        })
+
+        if (bail) {
+          if (tap) {
+            console.log('Bail out!')
+          }
+          return false
+        }
+
+        passed = false
       }
     }
 
     for (const fn of after) await fn()
-    rgb.greenln(`\n✓ ${ tests.filter( test => typeof test.group === 'undefined' ).length }`)
+    if (!tap) {
+      rgb.greenln(`\n✓ ${ tests.filter( test => typeof test.group === 'undefined' ).length }`)
+    }
     console.info('\n')
-    return true
+    return passed
+  }
+
+  function emit(result) {
+    if (result.group) {
+      if (tap) {
+        console.log( `#   ${ result.group }` )
+      }
+      else if (quiet) {
+        rgb.cyan(`\n  ${ result.group } `)
+      }
+      else {
+        rgb.cyan(`  ${ result.group }\n`)
+      }
+    }
+    else if (result.passed) {
+      if (tap) {
+        console.log(`ok ${ result.count } ${ result.test.name }`)
+      }
+      else if (quiet) {
+        rgb.gray('• ')
+      }
+      else {
+        rgb.gray(`    ${ result.test.name } `)
+        rgb.greenln( '✓' )
+      }
+    }
+    else if (result.failed) {
+      if (tap) {
+        console.log(`not ok ${ result.count } ${ result.test.name }`)
+      }
+      else if (quiet) {
+        rgb.red(`\n\n! ${ result.test.name } \n\n`)
+      }
+      else {
+        rgb.gray(`    ${ result.test.name } `)
+        rgb.redln( '✘' )
+        console.log('')
+      }
+
+      if (tap) {
+        console.log((result.e.stack ? result.e.stack.toString() : result.e.toString()).split('\n').map(line => `  ${ line }`).join( '\n'))
+      }
+      else {
+        prettyError(result.e)
+      }
+    }
   }
 
   return self
-
 }
-
 
 function prettyError(e) {
   const msg = e.stack
@@ -85,4 +144,5 @@ function prettyError(e) {
   const i = msg.indexOf('\n')
   rgb.yellowln(msg.slice(0, i))
   rgb.gray(msg.slice(i))
+  console.log('\n\n')
 }


### PR DESCRIPTION
Allows for producing TAP-compatible output, which people can run through the various TAP output formatters. Examples:

tap-vibrant
```console
headline

1..7

  group 1

  ✖ 1 should fail
    AssertionError [ERR_ASSERTION]: true == false
        at Object.fn (.../test.js:8:10)
        at Function.self.run (.../node_modules/baretest/baretest.js:56:20)
  ✔ 2 test 2
  ✔ 3 test 3

  group 2

  ✔ 4 test 4
  ✔ 5 test 5

  group 3

  ✔ 6 test 6
  ✔ 7 test 6
```

tap-spec
```console
  headline

  group 1

      AssertionError [ERR_ASSERTION]: true == false
          at Object.fn (.../test.js:8:10)
          at Function.self.run (.../node_modules/baretest/baretest.js:56:20)
    ✔ test 2
    ✔ test 3

  group 2

    ✔ test 4
    ✔ test 5

  group 3

    ✔ test 6
    ✔ test 7

  Failed Tests: There was 1 failure

    group 1

      ✖ should fail


  total:     7
  passing:   6
  failing:   1
  duration:  6ms
```